### PR TITLE
Add `{ suffixOnly: boolean }` option to return only `indicator` from `ordinal`

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,26 @@ ordinal(24) // '24th'
 To get just the indicator:
 
 ``` javascript
+var ordinal = require('ordinal')
+
+ordinal(1, { suffixOnly: true }) // 'st'
+ordinal(2, { suffixOnly: true }) // 'nd'
+ordinal(3, { suffixOnly: true }) // 'rd'
+ordinal(4, { suffixOnly: true }) // 'th'
+
+ordinal(11, { suffixOnly: true }) // 'th'
+ordinal(12, { suffixOnly: true }) // 'th'
+ordinal(13, { suffixOnly: true }) // 'th'
+
+ordinal(21, { suffixOnly: true }) // 'st'
+ordinal(22, { suffixOnly: true }) // 'nd'
+ordinal(23, { suffixOnly: true }) // 'rd'
+ordinal(24, { suffixOnly: true }) // 'th'
+```
+
+You can also import `indicator` directly:
+
+``` javascript
 var indicator = require('ordinal/indicator')
 
 indicator(1) // 'st'

--- a/index.js
+++ b/index.js
@@ -1,8 +1,10 @@
 var indicator = require('./indicator')
 
-function ordinal (i) {
+function ordinal (i, options) {
   if (typeof i !== 'number') throw new TypeError('Expected Number, got ' + (typeof i) + ' ' + i)
-  return i + indicator(i)
+  var suffix = indicator(i)
+
+  return options && options.suffixOnly ? suffix : i + suffix
 }
 
 ordinal.indicator = indicator

--- a/test/index.js
+++ b/test/index.js
@@ -16,3 +16,11 @@ test('throws on non-numbers', function (t) {
   }, /Expected Number, got string foo/)
   t.end()
 })
+
+test('returns suffix only', function (t) {
+  fixtures.forEach(function (x) {
+    t.equal(ordinal(x.i, { suffixOnly: true }), ordinal.indicator(x.i), x.i + ' === ' + ordinal.indicator(x.i))
+  })
+
+  t.end()
+})


### PR DESCRIPTION
Resolves #3

(I realize this is a relatively old issue, but figured I'd clear out the queue!)